### PR TITLE
Upon exiting, default colour is restored

### DIFF
--- a/news.py
+++ b/news.py
@@ -138,6 +138,7 @@ def console():
 
         # exit command
         elif cmd == "exit":
+            print(Style.RESET_ALL)
             exit()
 
         # show news


### PR DESCRIPTION
Every time I used to loose default colour of my terminal after using this program. And this was so because style was not being reset, or so to speak to use `print(Style.RESET_ALL)`  before exiting the program. 

* Before using it, terminal is like:  
![screenshot from 2017-12-13 16-37-49](https://user-images.githubusercontent.com/18527487/33937564-fdca0dfa-e029-11e7-9936-a734d98dd4c3.png)

* After using it, terminal is like:
![screenshot from 2017-12-13 17-23-56](https://user-images.githubusercontent.com/18527487/33937678-58b9fd1a-e02a-11e7-9e7e-b33c3a5269db.png)

But now, default colour will restored. 